### PR TITLE
Only unpause music after playing game if it was automatically paused

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -384,11 +384,11 @@ pub async fn perform_update(instance: Instance) {
 }
 
 pub async fn perform_play(path: PathBuf, executable: PathBuf, name: String, do_debug: bool) {
-    send_message(Message::MusicMessage(MusicCommand::Pause));
+    send_message(Message::MusicMessage(MusicCommand::AutoPause));
     if let Err(e) = play(path, executable, name, do_debug).await {
         error!("Failed to run game: {:#}", e);
     }
-    send_message(Message::MusicMessage(MusicCommand::Play));
+    send_message(Message::MusicMessage(MusicCommand::AutoPlay));
 }
 
 pub async fn play(path: PathBuf, executable: PathBuf, name: String, do_debug: bool) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,16 +181,7 @@ impl Application for ESLauncher {
             }
             Message::MusicMessage(cmd) => {
                 self.music_sender.send(cmd).ok();
-                self.music_state = match cmd {
-                    MusicCommand::Pause => MusicState::Paused,
-                    MusicCommand::Play => MusicState::Playing,
-                    MusicCommand::AutoPause => {
-                        if self.music_state == MusicState::Playing { MusicState::AutoPaused } else { self.music_state }
-                    }
-                    MusicCommand::AutoPlay => {
-                        if self.music_state == MusicState::AutoPaused { MusicState::Playing } else { self.music_state }
-                    }
-                }
+                self.music_state = cmd.update_state(self.music_state, || {});
             }
             Message::ViewChanged(view) => self.view = view,
             Message::PluginFrameLoaded(plugins) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,6 +184,12 @@ impl Application for ESLauncher {
                 self.music_state = match cmd {
                     MusicCommand::Pause => MusicState::Paused,
                     MusicCommand::Play => MusicState::Playing,
+                    MusicCommand::AutoPause => {
+                        if self.music_state == MusicState::Playing { MusicState::AutoPaused } else { self.music_state }
+                    }
+                    MusicCommand::AutoPlay => {
+                        if self.music_state == MusicState::AutoPaused { MusicState::Playing } else { self.music_state }
+                    }
                 }
             }
             Message::ViewChanged(view) => self.view = view,
@@ -284,12 +290,14 @@ impl Application for ESLauncher {
                     match self.music_state {
                         MusicState::Playing => style::pause_icon(),
                         MusicState::Paused => style::play_icon(),
+                        MusicState::AutoPaused => style::play_icon(),
                     },
                 )
                 .style(style::Button::Icon)
                 .on_press(Message::MusicMessage(match self.music_state {
                     MusicState::Playing => MusicCommand::Pause,
                     MusicState::Paused => MusicCommand::Play,
+                    MusicState::AutoPaused => MusicCommand::Play,
                 })),
             )
             .push(Text::new("Playing: Endless Sky Prototype by JimmyZenith").size(14));

--- a/src/music.rs
+++ b/src/music.rs
@@ -18,31 +18,24 @@ pub enum MusicCommand {
 
 impl MusicCommand {
     pub fn update_state<F: FnOnce()>(self, music_state: MusicState, f: F) -> MusicState {
-        match self {
-            MusicCommand::Pause => {
+        match (self, music_state) {
+            (MusicCommand::Pause, _) => {
                 f();
                 MusicState::Paused
             }
-            MusicCommand::Play => {
+            (MusicCommand::Play, _) => {
                 f();
                 MusicState::Playing
             }
-            MusicCommand::AutoPause => {
-                if music_state == MusicState::Playing {
-                    f();
-                    MusicState::AutoPaused
-                } else {
-                    music_state
-                }
+            (MusicCommand::AutoPause, MusicState::Playing) => {
+                f();
+                MusicState::AutoPaused
             }
-            MusicCommand::AutoPlay => {
-                if music_state == MusicState::AutoPaused {
-                    f();
-                    MusicState::Playing
-                } else {
-                    music_state
-                }
+            (MusicCommand::AutoPlay, MusicState::AutoPaused) => {
+                f();
+                MusicState::Playing
             }
+            (MusicCommand::AutoPause | MusicCommand::AutoPlay, _) => music_state,
         }
     }
 }

--- a/src/music.rs
+++ b/src/music.rs
@@ -12,12 +12,15 @@ const SONG: &[u8] = include_bytes!("../assets/endless-prototype.ogg");
 pub enum MusicCommand {
     Pause,
     Play,
+    AutoPause,
+    AutoPlay,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum MusicState {
     Playing,
     Paused,
+    AutoPaused,
 }
 
 pub fn spawn() -> Sender<MusicCommand> {
@@ -47,6 +50,18 @@ fn play(rx: &Receiver<MusicCommand>) -> Result<()> {
                 MusicCommand::Play => {
                     state = MusicState::Playing;
                     sink.play()
+                }
+                MusicCommand::AutoPause => {
+                    if state == MusicState::Playing {
+                        state = MusicState::AutoPaused;
+                        sink.pause()
+                    }
+                }
+                MusicCommand::AutoPlay => {
+                    if state == MusicState::AutoPaused {
+                        state = MusicState::Playing;
+                        sink.play()
+                    }
                 }
             }
         }


### PR DESCRIPTION
This implements the non-persistent half of #34, because having the music turn back on after quitting the game was irritating me.

Disclaimer: It's been a couple of years since I've written any Rust code, so this probably isn't the most elegant implementation.

There don't seem to be any automated tests, so I tested manually by starting and quitting a game with the music playing, which correctly paused and then unpaused the music, then pausing the music and starting and quitting a game, which correctly left the music paused.