### PR TITLE
Retain audio settings between game and application exits

### DIFF
--- a/src/instance.rs
+++ b/src/instance.rs
@@ -384,11 +384,11 @@ pub async fn perform_update(instance: Instance) {
 }
 
 pub async fn perform_play(path: PathBuf, executable: PathBuf, name: String, do_debug: bool) {
-    send_message(Message::MusicMessage(MusicCommand::TryPause));
+    send_message(Message::MusicMessage(MusicCommand::WeakPause));
     if let Err(e) = play(path, executable, name, do_debug).await {
         error!("Failed to run game: {:#}", e);
     }
-    send_message(Message::MusicMessage(MusicCommand::TryPlay));
+    send_message(Message::MusicMessage(MusicCommand::WeakPlay));
 }
 
 pub async fn play(path: PathBuf, executable: PathBuf, name: String, do_debug: bool) -> Result<()> {

--- a/src/instance.rs
+++ b/src/instance.rs
@@ -384,11 +384,11 @@ pub async fn perform_update(instance: Instance) {
 }
 
 pub async fn perform_play(path: PathBuf, executable: PathBuf, name: String, do_debug: bool) {
-    send_message(Message::MusicMessage(MusicCommand::Pause));
+    send_message(Message::MusicMessage(MusicCommand::TryPause));
     if let Err(e) = play(path, executable, name, do_debug).await {
         error!("Failed to run game: {:#}", e);
     }
-    send_message(Message::MusicMessage(MusicCommand::Play));
+    send_message(Message::MusicMessage(MusicCommand::TryPlay));
 }
 
 pub async fn play(path: PathBuf, executable: PathBuf, name: String, do_debug: bool) -> Result<()> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -193,8 +193,8 @@ impl Application for ESLauncher {
                 self.music_state = match cmd {
                     MusicCommand::Pause => MusicState::Paused,
                     MusicCommand::Play => MusicState::Playing,
-                    MusicCommand::TryPause => self.music_state,
-                    MusicCommand::TryPlay => self.music_state,
+                    MusicCommand::WeakPause => self.music_state,
+                    MusicCommand::WeakPlay => self.music_state,
                 };
                 if let Err(e) = save_music_state(self.music_state == MusicState::Playing) {
                     error!("Failed to save music state: {:#}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,13 +18,12 @@ use iced::{
     alignment, button, scrollable, Alignment, Application, Button, Column, Command, Container,
     Element, Length, Row, Scrollable, Settings, Space, Subscription, Text,
 };
-use music::save_music_state;
 use std::collections::VecDeque;
 use std::sync::Mutex;
 
 use crate::install_frame::InstallFrameMessage;
 use crate::instance::{Instance, InstanceMessage, InstanceState, Progress};
-use crate::music::{MusicCommand, MusicState, load_music_state};
+use crate::music::{MusicCommand, MusicState, save_music_state, load_music_state};
 use crate::plugins_frame::PluginMessage;
 
 mod archive;

--- a/src/music.rs
+++ b/src/music.rs
@@ -15,8 +15,8 @@ const SONG: &[u8] = include_bytes!("../assets/endless-prototype.ogg");
 pub enum MusicCommand {
     Pause,
     Play,
-    TryPause,
-    TryPlay,
+    WeakPause,
+    WeakPlay,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -53,10 +53,10 @@ fn play(rx: &Receiver<MusicCommand>) -> Result<()> {
                     state = MusicState::Playing;
                     sink.play()
                 }
-                MusicCommand::TryPause => {
+                MusicCommand::WeakPause => {
                     sink.pause()
                 }
-                MusicCommand::TryPlay => {
+                MusicCommand::WeakPlay => {
                     match state {
                         MusicState::Playing => {
                             sink.play()


### PR DESCRIPTION
Implements #34 

An application_save.json file is written to data_dir that saves the current play progress as a bool, which gets read at the opening of the app. Also stops the autoplay from happening.