### PR TITLE
Adds short descriptions and a button to visit plugin homepage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ ESLauncher2.log
 /*.deb
 /*.rpm
 /*.zst
+.vscode/launch.json
+.vscode/tasks.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -885,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "espim"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9513d943a78ffb4b23192ebbddea73b8147affe833956a87946fccb482305daa"
+checksum = "bc6482554a8dfd297583e0ff72ae79366a5730eea5653528a74e5355e6897073"
 dependencies = [
  "anyhow",
  "dirs",
@@ -1039,9 +1039,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -1630,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
+checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -2537,9 +2537,9 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "petgraph"
@@ -3845,9 +3845,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.1"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
+checksum = "31e6302e3bb753d46e83516cae55ae196fc0c309407cf11ab35cc51a4c2a4633"
 dependencies = [
  "form_urlencoded",
  "idna",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0"
 bitar = { version = "0.10", features=["rustls-tls"] }
 time = "0.3"
 dmg = "0.1.2"
-espim = "0.2"
+espim = "0.2.1"
 flate2 = "1.0"
 fs_extra = "1.3.0"
 futures = "0.3"
@@ -39,7 +39,9 @@ simplelog = "0.12.2"
 tar = "0.4"
 tokio = { version="1", default_features = false, features=["fs"] }
 ureq = { version = "2.9", default_features = false, features = ["json", "tls"] }
+url = "2.5.0"
 version = "3"
+webbrowser = "0.8.13"
 zip-extract = { version = "0.1.3", default_features = false, features = ["deflate"] }
 
 [dependencies.iced]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ anyhow = "1.0"
 bitar = { version = "0.10", features=["rustls-tls"] }
 time = "0.3"
 dmg = "0.1.2"
-espim = "0.2.1"
+espim = "0.2"
 flate2 = "1.0"
 fs_extra = "1.3.0"
 futures = "0.3"
@@ -39,9 +39,7 @@ simplelog = "0.12.2"
 tar = "0.4"
 tokio = { version="1", default_features = false, features=["fs"] }
 ureq = { version = "2.9", default_features = false, features = ["json", "tls"] }
-url = "2.5.0"
 version = "3"
-webbrowser = "0.8.13"
 zip-extract = { version = "0.1.3", default_features = false, features = ["deflate"] }
 
 [dependencies.iced]

--- a/src/plugins_frame.rs
+++ b/src/plugins_frame.rs
@@ -1,17 +1,15 @@
+use crate::style::icon_button;
 use crate::{get_data_dir, style, Message};
 use anyhow::Context;
 use anyhow::Result;
-use std::fs::File;
-use std::io::{Read, Write};
-use std::path::PathBuf;
-use crate::style::icon_button;
 use espim::Plugin as EspimPlugin;
 use iced::widget::{button, image, Column, Container, Image, Row, Scrollable, Text};
 use iced::{alignment, theme, Alignment, Color, Command, Element, Length};
 use lazy_static::lazy_static;
 use regex::Regex;
-use webbrowser;
-use url::Url;
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::PathBuf;
 
 lazy_static! {
     static ref CACHE_FILENAME_REGEX: Regex = Regex::new(r"[^\w.-]").unwrap();
@@ -118,16 +116,16 @@ impl Plugin {
             PluginMessage::OpenHREF => {
                 if let PluginState::Idle { espim_plugin } = &mut self.state {
                     if espim_plugin.is_available() {
-                        
-                        let url = espim_plugin.homepage().unwrap_or("No Homepage Available".to_string());
-                        if validate_url(&url) {
-                            if !webbrowser::open(&url).is_ok() {
-                                error!("URL could not be opened: {}", url);
+                        let url = espim_plugin
+                            .homepage()
+                            .unwrap_or("No homepage available".to_string());
+                        if url.trim().starts_with("http://") || url.trim().starts_with("https://") {
+                            if !open::that(&url.trim()).is_ok() {
+                                error!("URL could not be opened: '{}'", url);
                             }
                         } else {
-                            error!("URL-Validation broke: {}", url);
+                            error!("URL validation failed: '{}' is not http(s):// .", url);
                         }
-                        
                     }
                 }
             }
@@ -141,7 +139,6 @@ impl Plugin {
     }
 
     fn view(&self) -> Element<PluginMessage> {
-        
         let content = Row::new().spacing(10).padding(10);
         const ICON_DIMENSION: f32 = 48.;
         let mut icon_container = Row::new()
@@ -155,43 +152,49 @@ impl Plugin {
             );
         }
         let mut textbox = Column::new().width(Length::Fill);
-        let mut titlebox = Row::new().push(Text::new(&self.name).vertical_alignment(alignment::Vertical::Center).width(Length::Fill));
+        let mut titlebox = Row::new().push(
+            Text::new(&self.name)
+                .vertical_alignment(alignment::Vertical::Center)
+                .width(Length::Fill),
+        );
         let mut infos = Column::new();
-        
+
         let mut controls = Row::new().spacing(10);
 
         match &self.state {
             PluginState::Idle { espim_plugin } => {
                 let versions = espim_plugin.versions();
                 infos = infos
-                        .push(
-                            Text::new(if espim_plugin.is_installed() {
-                                format!("Installed: {}", versions.0.unwrap_or("unknown"))
-                            } else {
-                                String::from("Not installed")
-                            })
-                            .size(14)
-                            .style(theme::Text::Color(Color::from_rgb(0.6, 0.6, 0.6))),
-                        )
-                        .push(
-                                Text::new(if espim_plugin.is_available() {
+                    .push(
+                        Text::new(if espim_plugin.is_installed() {
+                            format!("Installed: {}", versions.0.unwrap_or("unknown"))
+                        } else {
+                            String::from("Not installed")
+                        })
+                        .size(14)
+                        .style(theme::Text::Color(Color::from_rgb(0.6, 0.6, 0.6))),
+                    )
+                    .push(
+                        Text::new(if espim_plugin.is_available() {
                             format!("Available: {}", versions.1.unwrap_or("unknown"))
                         } else {
                             String::from("Unavailable")
-                        }).size(14).style(theme::Text::Color(Color::from_rgb(0.6, 0.6, 0.6)))
-                        )
-                        .push(
-                            Row::new().spacing(10).padding(10)
-                        )       
-                        .push(
-                            Text::new(
-                                format!("Description: {}", espim_plugin.description().unwrap_or("Not available".to_string()))
-                            )
-                            .size(14)
-                            .width(Length::Shrink)
-                            .style(theme::Text::Color(Color::from_rgb(0.6, 0.6, 0.6))),
-                        );
-                        
+                        })
+                        .size(14)
+                        .style(theme::Text::Color(Color::from_rgb(0.6, 0.6, 0.6))),
+                    )
+                    .push(Row::new().spacing(10).padding(10))
+                    .push(
+                        Text::new(format!(
+                            "Description: {}",
+                            espim_plugin
+                                .description()
+                                .unwrap_or("Not available".to_string())
+                        ))
+                        .size(14)
+                        .width(Length::Shrink)
+                        .style(theme::Text::Color(Color::from_rgb(0.6, 0.6, 0.6))),
+                    );
 
                 let mut install_button =
                     button::Button::new(style::update_icon()).style(icon_button()); // TODO: Use other icon here?
@@ -205,14 +208,15 @@ impl Plugin {
                     remove_button = remove_button.on_press(PluginMessage::Remove)
                 }
 
-                let mut href_button =
-                    button::Button::new(style::href_icon()).style(icon_button()); // TODO: Use other icon here?
-                    if espim_plugin.is_available() {
-                        href_button = href_button.on_press(PluginMessage::OpenHREF)
-                    }
+                let mut href_button = button::Button::new(style::href_icon()).style(icon_button()); // TODO: Use other icon here?
+                if espim_plugin.is_available() {
+                    href_button = href_button.on_press(PluginMessage::OpenHREF)
+                }
 
-                controls = controls.push(href_button).push(install_button).push(remove_button);
-                
+                controls = controls
+                    .push(href_button)
+                    .push(install_button)
+                    .push(remove_button);
             }
             PluginState::Working => {
                 infos = infos.push(
@@ -223,15 +227,9 @@ impl Plugin {
             }
         };
         titlebox = titlebox.push(controls);
-        textbox = textbox
-            .push(titlebox)
-            .push(infos);
+        textbox = textbox.push(titlebox).push(infos);
 
-        content
-            .push(icon_container)
-            .push(textbox)
-            .into()
-            
+        content.push(icon_container).push(textbox).into()
     }
 }
 
@@ -313,14 +311,4 @@ pub async fn perform_install(mut plugin: EspimPlugin) -> EspimPlugin {
         error!("Install failed: {:#}", e)
     }
     plugin
-}
-
-fn validate_url(url: &str) -> bool {
-    match Url::parse(&url) {
-        Ok(parsed_url) => {
-            // Überprüft, ob das Schema http oder https ist
-            parsed_url.scheme() == "http" || parsed_url.scheme() == "https"
-        },
-        Err(_) => false,
-    }
 }

--- a/src/plugins_frame.rs
+++ b/src/plugins_frame.rs
@@ -175,7 +175,13 @@ impl Plugin {
                     remove_button = remove_button.on_press(PluginMessage::Remove)
                 }
 
-                controls = controls.push(install_button).push(remove_button);
+                let mut href_button =
+                    button::Button::new(style::href_icon()).style(icon_button()); // TODO: Use other icon here?
+                    if false {
+                        // To-Do: go to Plugin github page
+                    }
+
+                controls = controls.push(href_button).push(install_button).push(remove_button);
             }
             PluginState::Working => {
                 infos = infos.push(

--- a/src/style.rs
+++ b/src/style.rs
@@ -23,6 +23,9 @@ pub fn debug_icon() -> Text<'static> {
 pub fn play_icon() -> Text<'static> {
     icon('\u{EA1C}')
 }
+pub fn href_icon() -> Text<'static> {
+    icon('\u{E9CB}')
+}
 
 pub fn update_icon() -> Text<'static> {
     icon('\u{E9C7}')


### PR DESCRIPTION

![example](https://github.com/EndlessSkyCommunity/ESLauncher2/assets/40619091/a45ee270-7e10-46b3-9c14-804bd2c10d14)

This is a potential solve for #270 and #213, but is dependent on my [pull request on espim](https://github.com/EndlessSkyCommunity/espim/pull/14), since those values were private before.

until the espim merge is available through cargo, this should remain a draft request, i guess.

the Cargo.toml "espim" reference needs to be updated for that and the Cargo.lock needs to be regenerated.

