### PR TITLE
UI Tweaks - Borders, Spacing, Color

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ zip-extract = { version = "0.1.3", default-features = false, features = ["deflat
 [dependencies.iced]
 version = "0.12.1"
 default-features = false
-features = ["advanced", "image", "tokio"]
+features = ["web-colors", "advanced", "image", "tokio"]
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"

--- a/src/github.rs
+++ b/src/github.rs
@@ -39,16 +39,12 @@ pub struct PRHead {
 
 pub fn get_pr(id: u16) -> Result<PR> {
     make_request(&format!(
-        "https://api.github.com/repos/endless-sky/endless-sky/pulls/{}",
-        id
+        "https://api.github.com/repos/endless-sky/endless-sky/pulls/{id}"
     ))
 }
 
 pub fn unblock_artifact_download(artifact_id: u32) -> String {
-    format!(
-        "https://artifact-unblocker.mcofficer.workers.dev/artifact/{}",
-        artifact_id,
-    )
+    format!("https://artifact-unblocker.mcofficer.workers.dev/artifact/{artifact_id}",)
 }
 
 #[derive(Deserialize, Debug)]
@@ -92,8 +88,7 @@ pub fn get_latest_workflow_run(
     head_repo_id: u32,
 ) -> Result<WorkflowRun> {
     let mut pages: Vec<WorkflowRuns> = make_paginated_request(&format!(
-        "https://api.github.com/repos/endless-sky/endless-sky/actions/workflows/{}/runs?branch={}",
-        workflow_id, branch
+        "https://api.github.com/repos/endless-sky/endless-sky/actions/workflows/{workflow_id}/runs?branch={branch}"
     ))?;
 
     let runs: Vec<WorkflowRun> = pages
@@ -136,8 +131,7 @@ impl Artifact for WorkflowRunArtifact {
 
 pub fn get_workflow_run_artifacts(run_id: u64) -> Result<Vec<WorkflowRunArtifact>> {
     let artifacts: WorkflowRunArtifacts = make_request(&format!(
-        "https://api.github.com/repos/endless-sky/endless-sky/actions/runs/{}/artifacts",
-        run_id
+        "https://api.github.com/repos/endless-sky/endless-sky/actions/runs/{run_id}/artifacts"
     ))?;
     info!(
         "Got {} artifacts for workflow run {}",
@@ -158,8 +152,7 @@ pub struct GitObject {
 
 pub fn get_git_ref(name: &str) -> Result<GitRef> {
     make_request(&format!(
-        "https://api.github.com/repos/endless-sky/endless-sky/git/ref/{}",
-        name
+        "https://api.github.com/repos/endless-sky/endless-sky/git/ref/{name}"
     ))
 }
 
@@ -171,13 +164,12 @@ pub struct Release {
 
 pub fn get_release_by_tag(tag: &str) -> Result<Release> {
     make_request(&format!(
-        "https://api.github.com/repos/endless-sky/endless-sky/releases/tags/{}",
-        tag
+        "https://api.github.com/repos/endless-sky/endless-sky/releases/tags/{tag}"
     ))
 }
 
 pub fn get_latest_release(repo_slug: &str) -> Result<String> {
-    let url = &format!("https://github.com/{}/releases/latest", repo_slug);
+    let url = &format!("https://github.com/{repo_slug}/releases/latest");
     let res = ureq::get(url).call()?;
 
     if res.status() >= 400 {
@@ -186,7 +178,7 @@ pub fn get_latest_release(repo_slug: &str) -> Result<String> {
             res.status(),
             res.status_text(),
             url,
-        )
+        );
     };
 
     Ok(res.get_url().rsplit_once('/').unwrap().1.to_string())
@@ -214,8 +206,7 @@ impl Artifact for ReleaseAsset {
 
 pub fn get_release_assets(release_id: i64) -> Result<Vec<ReleaseAsset>> {
     let assets: ReleaseAssets = make_request(&format!(
-        "https://api.github.com/repos/endless-sky/endless-sky/releases/{}/assets",
-        release_id
+        "https://api.github.com/repos/endless-sky/endless-sky/releases/{release_id}/assets"
     ))?;
     info!("Got {} assets for release {}", assets.0.len(), release_id);
     Ok(assets.0)
@@ -231,7 +222,7 @@ fn make_request<T: DeserializeOwned>(url: &str) -> Result<T> {
             res.status(),
             res.status_text(),
             url,
-        )
+        );
     }
     Ok(res.into_json()?)
 }
@@ -281,7 +272,7 @@ fn check_ratelimit(res: &ureq::Response) {
                         };
                     }
                 } else if remaining < 10 {
-                    warn!("Only {} github API requests remaining", remaining)
+                    warn!("Only {} github API requests remaining", remaining);
                 }
             }
             Err(e) => warn!("Failed to parse X-RateLimit-Remaining Header: {}", e),

--- a/src/install.rs
+++ b/src/install.rs
@@ -18,7 +18,7 @@ pub fn install(
     mut instance_source: InstanceSource,
 ) -> Result<Instance> {
     info!("Installing to {}", destination.to_string_lossy());
-    if let InstanceType::Unknown = instance_type {
+    if instance_type == InstanceType::Unknown {
         return Err(anyhow!("Cannot install InstanceType::Unknown",));
     }
     send_progress_message(&name, "Preparing directories".into());
@@ -67,7 +67,7 @@ pub fn install(
     let mut executable_path = destination.clone();
     executable_path.push(instance_type.executable().unwrap());
 
-    if let InstanceType::AppImage = instance_type {
+    if instance_type == InstanceType::AppImage {
         fs::rename(&archive_file, &executable_path)?;
     } else if cfg!(target_os = "macos") && archive_file.to_string_lossy().contains("dmg") {
         send_progress_message(&name, "Processing DMG file".into());
@@ -81,7 +81,7 @@ pub fn install(
 
     // TODO: Remove this after a while, only exists for backwards compatibility with pre-cmake PRs
     if InstanceType::Windows == instance_type && !executable_path.exists() {
-        executable_path.set_file_name("EndlessSky.exe")
+        executable_path.set_file_name("EndlessSky.exe");
     }
 
     // upload-artifact doesn't preserve permissions, so we need to set the executable bit here
@@ -177,12 +177,12 @@ pub fn choose_artifact<A: Artifact>(artifacts: Vec<A>, instance_type: InstanceTy
 
 #[cfg(unix)]
 fn chmod_x(file: &PathBuf) {
-    if let Err(e) = fs::set_permissions(&file, PermissionsExt::from_mode(0o755)) {
+    if let Err(e) = fs::set_permissions(file, PermissionsExt::from_mode(0o755)) {
         warn!(
             "Failed to set executable bit for {}: {}",
             file.to_string_lossy(),
             e
-        )
+        );
     }
 }
 

--- a/src/install_frame.rs
+++ b/src/install_frame.rs
@@ -40,7 +40,7 @@ pub struct InstanceSource {
 impl Default for InstanceSource {
     fn default() -> Self {
         Self {
-            identifier: String::from(""),
+            identifier: String::new(),
             r#type: InstanceSourceType::Continuous,
         }
     }
@@ -52,7 +52,7 @@ impl InstanceSourceType {
 
 impl fmt::Display for InstanceSourceType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 
@@ -72,19 +72,19 @@ impl InstallFrame {
                         Message::Dummy,
                     );
                 } else {
-                    error!("Could not get instances directory from AppDirs")
+                    error!("Could not get instances directory from AppDirs");
                 }
             }
             InstallFrameMessage::SourceTypeChanged(source_type) => self.source.r#type = source_type,
             InstallFrameMessage::NameChanged(name) => {
                 if let Some(invalid) = name.chars().rfind(|c| BLACKLISTED_CHARS.contains(c)) {
-                    error!("Invalid character: '{}'", invalid)
+                    error!("Invalid character: '{}'", invalid);
                 } else {
-                    self.name = name
+                    self.name = name;
                 }
             }
             InstallFrameMessage::SourceIdentifierChanged(identifier) => {
-                self.source.identifier = identifier
+                self.source.identifier = identifier;
             }
         }
         Command::none()
@@ -95,7 +95,7 @@ impl InstallFrame {
             Column::new().spacing(10).push(Text::new("Choose a Type:")),
             |column, source_type| {
                 column.push(Radio::new(
-                    format!("{:?}", source_type),
+                    format!("{source_type:?}"),
                     *source_type,
                     Some(self.source.r#type),
                     InstallFrameMessage::SourceTypeChanged,
@@ -119,7 +119,7 @@ impl InstallFrame {
                     InstanceType::AppImage
                 } else {
                     InstanceType::MacOS
-                }))
+                }));
         }
 
         Container::new(Scrollable::new(

--- a/src/instances_frame.rs
+++ b/src/instances_frame.rs
@@ -54,7 +54,18 @@ impl InstancesFrame {
                 .values()
                 .fold(instances_column, |column, instance| {
                     column
-                        .push(iced::widget::horizontal_rule(2))
+                        .push(
+                            iced::widget::horizontal_rule(2).style(iced::theme::Rule::from(
+                                |theme: &iced::Theme| {
+                                    let mut appearance = iced::widget::rule::StyleSheet::appearance(
+                                        theme,
+                                        &Default::default(),
+                                    );
+                                    appearance.color.a *= 0.75;
+                                    appearance
+                                },
+                            )),
+                        )
                         .push(instance.view().map(move |message| {
                             Message::InstanceMessage(instance.name.clone(), message)
                         }))

--- a/src/instances_frame.rs
+++ b/src/instances_frame.rs
@@ -31,7 +31,7 @@ impl InstancesFrame {
     pub fn view(&self) -> Element<Message> {
         let instances_column = Column::new()
             .padding(20)
-            .spacing(20)
+            .spacing(5)
             .align_items(Alignment::Center);
         let instances_list: Element<_> = if self.instances.is_empty() {
             instances_column
@@ -53,12 +53,11 @@ impl InstancesFrame {
             self.instances
                 .values()
                 .fold(instances_column, |column, instance| {
-                    let name = instance.name.clone();
-                    column.push(
-                        instance
-                            .view()
-                            .map(move |message| Message::InstanceMessage(name.clone(), message)),
-                    )
+                    column
+                        .push(iced::widget::horizontal_rule(2))
+                        .push(instance.view().map(move |message| {
+                            Message::InstanceMessage(instance.name.clone(), message)
+                        }))
                 })
                 .into()
         };

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -72,7 +72,7 @@ fn open_logfile() -> Option<File> {
     let mut path = std::env::current_dir().unwrap();
     if let Some(data_dir) = get_data_dir() {
         match fs::create_dir_all(&data_dir) {
-            Ok(_) => path = data_dir,
+            Ok(()) => path = data_dir,
             Err(e) => eprintln!(
                 "Creation of data dir ({}) failed due to {}! Falling back to logging to the PWD ({})",
                 data_dir.to_string_lossy(), e,

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,17 +228,30 @@ impl Application for ESLauncher {
             .push::<Element<'_, Message>>(
                 Tab::Instances,
                 TabLabel::Text("Instances".into()),
-                Row::new()
-                    .push(self.instances_frame.view())
-                    .push(self.install_frame.view().map(Message::InstallFrameMessage))
-                    .spacing(50)
-                    .padding(15)
-                    .into(),
+                iced::widget::column([
+                    iced::widget::horizontal_rule(2).into(),
+                    Row::new()
+                        .push(self.instances_frame.view())
+                        .push(iced::widget::vertical_rule(2))
+                        .push(self.install_frame.view().map(Message::InstallFrameMessage))
+                        .spacing(10)
+                        .padding(iced::Padding {
+                            top: 0.0,
+                            right: 15.0,
+                            bottom: 0.0,
+                            left: 15.0,
+                        })
+                        .into(),
+                ])
+                .into(),
             )
             .push(
                 Tab::Plugins,
                 TabLabel::Text("Plugins".into()),
-                self.plugins_frame.view(),
+                iced::widget::column([
+                    iced::widget::horizontal_rule(2).into(),
+                    self.plugins_frame.view().into(),
+                ]),
             )
             .set_active_tab(&self.active_tab)
             .tab_bar_style(tab_bar());
@@ -265,6 +278,14 @@ impl Application for ESLauncher {
         let content = Column::new()
             .align_items(Alignment::Center)
             .push(tabs.height(Length::FillPortion(3)))
+            .push(
+                iced::widget::container(iced::widget::horizontal_rule(2)).padding(iced::Padding {
+                    top: 0.0,
+                    right: 10.0,
+                    bottom: 0.0,
+                    left: 10.0,
+                }),
+            )
             .push(
                 Scrollable::new(logbox)
                     .width(Length::Fill)

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,7 @@ use iced::{
 };
 use iced_aw::{TabLabel, Tabs};
 use std::collections::VecDeque;
-use std::sync::{Arc, Mutex};
+use std::sync::Mutex;
 
 use crate::install_frame::InstallFrameMessage;
 use crate::instance::{Instance, InstanceMessage, InstanceState, Progress};

--- a/src/music.rs
+++ b/src/music.rs
@@ -28,7 +28,7 @@ pub fn spawn(initial_state: MusicState) -> Sender<MusicCommand> {
     let (tx, rx) = mpsc::channel();
     thread::spawn(move || {
         if let Err(e) = play(&rx, initial_state) {
-            error!("Music thread crashed: {:#}", e)
+            error!("Music thread crashed: {:#}", e);
         }
     });
     tx
@@ -46,16 +46,16 @@ fn play(rx: &Receiver<MusicCommand>, initial_state: MusicState) -> Result<()> {
             match cmd {
                 MusicCommand::Pause => {
                     state = MusicState::Paused;
-                    fade(&sink, true)
+                    fade(&sink, true);
                 }
                 MusicCommand::Play => {
                     state = MusicState::Playing;
-                    fade(&sink, false)
+                    fade(&sink, false);
                 }
                 MusicCommand::WeakPause => fade(&sink, true),
                 MusicCommand::WeakPlay => {
-                    if let MusicState::Playing = state {
-                        fade(&sink, false)
+                    if state == MusicState::Playing {
+                        fade(&sink, false);
                     }
                 }
             }
@@ -84,6 +84,6 @@ fn fade(sink: &Sink, out: bool) {
     }
 
     if out {
-        sink.pause()
+        sink.pause();
     }
 }

--- a/src/plugins_frame.rs
+++ b/src/plugins_frame.rs
@@ -44,20 +44,31 @@ impl PluginsFrameState {
                 ),
             ),
             Self::Ready { plugins } => {
-                let plugin_list = plugins.iter().fold(
-                    Column::new()
-                        .padding(20)
-                        .spacing(5)
-                        .width(Length::Fill)
-                        .align_items(Alignment::Center),
-                    |column, plugin| {
-                        column.push(iced::widget::horizontal_rule(2)).push(
-                            plugin
-                                .view()
-                                .map(move |msg| Message::PluginMessage(plugin.name.clone(), msg)),
-                        )
-                    },
-                );
+                let plugin_list =
+                    plugins.iter().fold(
+                        Column::new()
+                            .padding(20)
+                            .spacing(5)
+                            .width(Length::Fill)
+                            .align_items(Alignment::Center),
+                        |column, plugin| {
+                            column
+                                .push(iced::widget::horizontal_rule(2).style(
+                                    iced::theme::Rule::from(|theme: &iced::Theme| {
+                                        let mut appearance =
+                                            iced::widget::rule::StyleSheet::appearance(
+                                                theme,
+                                                &Default::default(),
+                                            );
+                                        appearance.color.a *= 0.75;
+                                        appearance
+                                    }),
+                                ))
+                                .push(plugin.view().map(move |msg| {
+                                    Message::PluginMessage(plugin.name.clone(), msg)
+                                }))
+                        },
+                    );
 
                 Container::new(
                     Column::new()

--- a/src/plugins_frame.rs
+++ b/src/plugins_frame.rs
@@ -44,20 +44,34 @@ impl PluginsFrameState {
                 ),
             ),
             Self::Ready { plugins } => {
-                let plugin_list = plugins.iter().fold(
-                    Column::new()
-                        .padding(20)
-                        .spacing(20)
-                        .align_items(Alignment::Center),
-                    |column, plugin| {
-                        let name = plugin.name.clone();
-                        column.push(
-                            plugin
-                                .view()
-                                .map(move |msg| Message::PluginMessage(name.clone(), msg)),
-                        )
-                    },
-                );
+                let mut plugin_iter = plugins.iter();
+
+                let mut column_contents = Vec::with_capacity(plugins.len() * 2);
+
+                if let Some(plugin) = plugin_iter.next() {
+                    let name = plugin.name.clone();
+                    column_contents.push(
+                        plugin
+                            .view()
+                            .map(move |msg| Message::PluginMessage(name.clone(), msg)),
+                    );
+                }
+                for plugin in plugin_iter {
+                    column_contents.push(iced::widget::horizontal_rule(2).into());
+
+                    let name = plugin.name.clone();
+                    column_contents.push(
+                        plugin
+                            .view()
+                            .map(move |msg| Message::PluginMessage(name.clone(), msg)),
+                    );
+                }
+
+                let plugin_list = Column::from_vec(column_contents)
+                    .padding(20)
+                    .spacing(20)
+                    .width(Length::Fill)
+                    .align_items(Alignment::Center);
 
                 Container::new(
                     Column::new()
@@ -77,13 +91,13 @@ pub enum PluginMessage {
     Install,
     Remove,
     OpenHREF,
-    WorkFinished(EspimPlugin),
+    WorkFinished(Box<EspimPlugin>),
 }
 
 #[derive(Debug, Clone)]
 pub enum PluginState {
     Working,
-    Idle { espim_plugin: EspimPlugin },
+    Idle { espim_plugin: Box<EspimPlugin> },
 }
 
 #[derive(Debug, Clone)]
@@ -101,15 +115,15 @@ impl Plugin {
                     let name = self.name.clone();
                     let plugin = espim_plugin.clone();
                     self.state = PluginState::Working;
-                    return Command::perform(perform_install(plugin), move |p| {
-                        Message::PluginMessage(name.clone(), PluginMessage::WorkFinished(p))
+                    return Command::perform(perform_install(*plugin), move |p| {
+                        Message::PluginMessage(name, PluginMessage::WorkFinished(Box::new(p)))
                     });
                 }
             }
             PluginMessage::Remove => {
                 if let PluginState::Idle { espim_plugin } = &mut self.state {
                     espim_plugin.remove().unwrap_or_else(|e| {
-                        error!("Failed to remove Plug-In {}: {}", self.name, e)
+                        error!("Failed to remove Plug-In {}: {}", self.name, e);
                     });
                 }
             }
@@ -193,18 +207,18 @@ impl Plugin {
                 let mut install_button =
                     button::Button::new(style::update_icon()).style(icon_button()); // TODO: Use other icon here?
                 if espim_plugin.is_available() {
-                    install_button = install_button.on_press(PluginMessage::Install)
+                    install_button = install_button.on_press(PluginMessage::Install);
                 }
 
                 let mut remove_button =
                     button::Button::new(style::delete_icon()).style(theme::Button::Destructive);
                 if espim_plugin.is_installed() {
-                    remove_button = remove_button.on_press(PluginMessage::Remove)
+                    remove_button = remove_button.on_press(PluginMessage::Remove);
                 }
 
                 let mut href_button = button::Button::new(style::href_icon()).style(icon_button()); // TODO: Use other icon here?
                 if espim_plugin.is_available() {
-                    href_button = href_button.on_press(PluginMessage::OpenHREF)
+                    href_button = href_button.on_press(PluginMessage::OpenHREF);
                 }
 
                 controls = controls
@@ -217,7 +231,7 @@ impl Plugin {
                     Text::new("Working...")
                         .size(14)
                         .style(theme::Text::Color(Color::from_rgb(0.6, 0.6, 0.6))),
-                )
+                );
             }
         };
         let header = Row::new()
@@ -241,10 +255,12 @@ pub async fn load_plugins() -> Vec<Plugin> {
                     .map_err(|e| debug!("failed to fetch icon: {}", e))
                     .ok();
                 plugins.push(Plugin {
-                    state: PluginState::Idle { espim_plugin: p },
+                    state: PluginState::Idle {
+                        espim_plugin: Box::new(p),
+                    },
                     name,
                     icon,
-                })
+                });
             }
         }
         Err(e) => {
@@ -300,13 +316,13 @@ pub async fn perform_install(mut plugin: EspimPlugin) -> EspimPlugin {
                 }
             }
             Err(e) => {
-                error!("Failed to get cache filename: {}", e)
+                error!("Failed to get cache filename: {}", e);
             }
         };
     }
 
     if let Err(e) = plugin.download() {
-        error!("Install failed: {:#}", e)
+        error!("Install failed: {:#}", e);
     }
     plugin
 }

--- a/src/plugins_frame.rs
+++ b/src/plugins_frame.rs
@@ -44,34 +44,20 @@ impl PluginsFrameState {
                 ),
             ),
             Self::Ready { plugins } => {
-                let mut plugin_iter = plugins.iter();
-
-                let mut column_contents = Vec::with_capacity(plugins.len() * 2);
-
-                if let Some(plugin) = plugin_iter.next() {
-                    let name = plugin.name.clone();
-                    column_contents.push(
-                        plugin
-                            .view()
-                            .map(move |msg| Message::PluginMessage(name.clone(), msg)),
-                    );
-                }
-                for plugin in plugin_iter {
-                    column_contents.push(iced::widget::horizontal_rule(2).into());
-
-                    let name = plugin.name.clone();
-                    column_contents.push(
-                        plugin
-                            .view()
-                            .map(move |msg| Message::PluginMessage(name.clone(), msg)),
-                    );
-                }
-
-                let plugin_list = Column::from_vec(column_contents)
-                    .padding(20)
-                    .spacing(20)
-                    .width(Length::Fill)
-                    .align_items(Alignment::Center);
+                let plugin_list = plugins.iter().fold(
+                    Column::new()
+                        .padding(20)
+                        .spacing(5)
+                        .width(Length::Fill)
+                        .align_items(Alignment::Center),
+                    |column, plugin| {
+                        column.push(iced::widget::horizontal_rule(2)).push(
+                            plugin
+                                .view()
+                                .map(move |msg| Message::PluginMessage(plugin.name.clone(), msg)),
+                        )
+                    },
+                );
 
                 Container::new(
                     Column::new()
@@ -80,7 +66,12 @@ impl PluginsFrameState {
                         .width(Length::Fill),
                 )
                 .width(Length::Fill)
-                .padding(30)
+                .padding(iced::Padding {
+                    top: 0.0,
+                    right: 30.0,
+                    bottom: 0.0,
+                    left: 30.0,
+                })
             }
         }
     }

--- a/src/style.rs
+++ b/src/style.rs
@@ -1,7 +1,6 @@
 use iced::border::Radius;
 use iced::widget::{button, container, Text};
 use iced::{alignment, Background, Border, Color, Font, Length, Theme, Vector};
-use std::default::Default;
 use std::rc::Rc;
 
 fn icon(unicode: char) -> Text<'static> {
@@ -66,11 +65,11 @@ impl button::StyleSheet for ButtonStyle {
 
     fn active(&self, _: &Self::Style) -> button::Appearance {
         match self {
-            ButtonStyle::Icon => button::Appearance {
+            Self::Icon => button::Appearance {
                 text_color: Color::from_rgb(0.5, 0.5, 0.5),
                 ..Default::default()
             },
-            ButtonStyle::Text => button::Appearance {
+            Self::Text => button::Appearance {
                 background: Some(Background::Color(Color::WHITE)),
                 border: Border {
                     color: Color::from_rgb(0.8, 0.8, 0.8),
@@ -87,12 +86,12 @@ impl button::StyleSheet for ButtonStyle {
         let active = self.active(style);
 
         match self {
-            ButtonStyle::Icon => button::Appearance {
+            Self::Icon => button::Appearance {
                 text_color: Color::from_rgb(0.3, 0.3, 0.3),
                 shadow_offset: active.shadow_offset + Vector::new(0.0, 1.0),
                 ..active
             },
-            ButtonStyle::Text => button::Appearance {
+            Self::Text => button::Appearance {
                 border: Border {
                     color: Color::from_rgb(0.4, 0.4, 0.4),
                     ..Default::default()
@@ -106,7 +105,7 @@ impl button::StyleSheet for ButtonStyle {
     fn disabled(&self, style: &Self::Style) -> button::Appearance {
         let active = self.active(style);
         match self {
-            ButtonStyle::Text => button::Appearance {
+            Self::Text => button::Appearance {
                 text_color: Color::from_rgb(0.5, 0.5, 0.5),
                 ..active
             },

--- a/src/update.rs
+++ b/src/update.rs
@@ -8,7 +8,7 @@ use std::path::PathBuf;
 use tokio::fs::OpenOptions;
 
 pub async fn update_instance(instance: Instance) -> Result<Instance> {
-    if let InstanceType::Unknown = instance.instance_type {
+    if instance.instance_type == InstanceType::Unknown {
         return Err(anyhow!("Cannot update InstanceType::Unknown"));
     }
 
@@ -129,6 +129,7 @@ async fn bitar_update_archive(
     let mut target = OpenOptions::new()
         .read(true)
         .create(true)
+        .truncate(true)
         .write(true)
         .open(&target_path)
         .await?;


### PR DESCRIPTION
Changes to UI:
- Borders around content (instances, plugins, separators)
- Change main colour from blue to grey
- Use the iced/web-colors feature to fix text gamma
- Make plugins fill the area more

Also ran clippy --fix on the codebase (probably should be a separate PR, but I'm too lazy to go and separate it out now)

![image](https://github.com/EndlessSkyCommunity/ESLauncher2/assets/101683475/6d7fd28d-250c-451a-b645-26799f598795)

![image](https://github.com/EndlessSkyCommunity/ESLauncher2/assets/101683475/7678e86a-6c2d-4442-857b-26e25fdcdca4)

